### PR TITLE
retain order of passed-in groups, not groups returned from AD

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,11 +62,6 @@ function activedirectoryuserobject (config, options) {
 
         req[opts.userObject][key] = groups
 
-        const groupFilter = group => opts.properties[key].values.indexOf(group) !== -1
-        if (opts.properties[key].values !== 'all') {
-          req[opts.userObject][key] = groups.filter(groupFilter)
-        }
-
         const groupFilter = group => groups.indexOf(group) !== -1
         if (opts.properties[key].values !== 'all') {
           debug(`Filtering ${JSON.stringify(opts.properties[key].values)} to only groups that the user has, retaining order of passed-in groups.`)

--- a/index.js
+++ b/index.js
@@ -64,9 +64,13 @@ function activedirectoryuserobject (config, options) {
 
         const groupFilter = group => opts.properties[key].values.indexOf(group) !== -1
         if (opts.properties[key].values !== 'all') {
-          debug(`Filtering groups to only results that match:
-            ${JSON.stringify(opts.properties[key].values)}`)
           req[opts.userObject][key] = groups.filter(groupFilter)
+        }
+
+        const groupFilter = group => groups.indexOf(group) !== -1
+        if (opts.properties[key].values !== 'all') {
+          debug(`Filtering ${JSON.stringify(opts.properties[key].values)} to only groups that the user has, retaining order of passed-in groups.`)
+          req[opts.userObject][key] = opts.properties[key].values.filter(groupFilter)
         }
 
         if (req[opts.userObject][key].length === 0) {


### PR DESCRIPTION
System takes a list of groups from the application, then filters down a user's list of groups using that list. Then it takes the first entry and returns that.
Unfortunately that results in this happening:
//passed in
[1,2,3]
//fetched from ldap
[4,3,2,1,0]
//returned
[3]
//expected
[1]

This causes issues with groups/roles, because in this case role 1 has the most privileges, and a user might have more than one group/role assigned to them.

To fix this we just needed to flip the filters around so that the passed in list was filtered by the fetched list instead.
